### PR TITLE
fix: fixed minor spelling error

### DIFF
--- a/components/CommunityPage/communityList.jsx
+++ b/components/CommunityPage/communityList.jsx
@@ -22,7 +22,7 @@ const CommunityList = () => {
         "Community members can contribute chaos experiments, file issues, raise pull requests, and provide feedback to help enhance the user experience and bring in new enhancements to developLitmusChaos.",
       paragraph2:
         "Check out the CONTRIBUTING.md page on Litmus repository for instructions on how to contribute.",
-      linkText: "About Contriuting on Github",
+      linkText: "About Contributing on Github",
       imgUrl: "/communityPage/githubCard.png",
       width: "w-1/3",
       link: "https://github.com/litmuschaos/litmus/blob/master/CONTRIBUTING.md"


### PR DESCRIPTION
fixed a minor spelling error at [https://litmuschaos.io/community](https://litmuschaos.io/community)

![image](https://github.com/litmuschaos/litmus-website-2/assets/81870866/3ad2202a-d8c5-4c07-b295-92a242693677)
