### PR TITLE
Relabel 'Get Started' Buttons

### DIFF
--- a/_includes/TopNavbar.jsx
+++ b/_includes/TopNavbar.jsx
@@ -21,7 +21,6 @@ import Image from "next/image"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { RegularButton, TextLink } from "./CTA"
-import NavbarBanner from "./NavbarBanner"
 
 const TopNavbar = () => {
   const url = "https://api.github.com/repos/litmuschaos/litmus"
@@ -92,7 +91,6 @@ const TopNavbar = () => {
             : ""
         }`}
       >
-        <NavbarBanner />
         <Container className={styles.navbarCont}>
           <nav className={styles.navbar}>
             <div className={styles.logoCont}>

--- a/_includes/TopNavbar.jsx
+++ b/_includes/TopNavbar.jsx
@@ -21,6 +21,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { RegularButton, TextLink } from "./CTA"
+import NavbarBanner from "./NavbarBanner"
 
 const TopNavbar = () => {
   const url = "https://api.github.com/repos/litmuschaos/litmus"
@@ -91,6 +92,7 @@ const TopNavbar = () => {
             : ""
         }`}
       >
+        <NavbarBanner />
         <Container className={styles.navbarCont}>
           <nav className={styles.navbar}>
             <div className={styles.logoCont}>
@@ -436,12 +438,11 @@ const TopNavbar = () => {
               </ul>
               <RegularButton
                 external
-                href="https://github.com/litmuschaos/litmus"
+                href="https://docs.litmuschaos.io/"
                 className="z-10 ml-4 lg:ml-6"
               >
                 <span className="flex items-center text-xs lg:text-sm">
-                  <GithubButton />
-                  Get Started
+                  Learn more
                 </span>
               </RegularButton>
             </div>

--- a/components/homepage/Hero.jsx
+++ b/components/homepage/Hero.jsx
@@ -26,12 +26,11 @@ const Hero = () => {
           </Paragraph>
           <div className="mt-4 flex gap-4 justify-center lg:justify-start">
             <RegularButton
-              href="https://github.com/litmuschaos/litmus"
+              href="https://docs.litmuschaos.io/"
               external
             >
               <span className="flex items-center">
-                <GithubButton />
-                Get Started
+                Learn more
               </span>
             </RegularButton>
             <OutlinedButton


### PR DESCRIPTION
This PR addresses the first and second points of the feature request in issue (https://github.com/litmuschaos/litmus-docs/issues/297) It modifies the 'Get Started' buttons on the Product landing page banner and the Product landing page by relabeling them to 'Learn More'  as recommended.